### PR TITLE
Fix typos in pyproject.toml and .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -15,4 +15,4 @@
 # More detailed documentation on the format and use of this file can be found at:
 # https://github.com/git/git/blob/master/Documentation/mailmap.txt
 
-Student Robotics <kit-brain@studentrobotics,org>
+Student Robotics <kit-brain@studentrobotics.org>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Student Robotics <kit-brain@studentrobotics.org>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/srobo/sr-robot3"
-homepage = "https://github.com/sr-robot3"
+homepage = "https://github.com/srobo/sr-robot3"
 documentation = "https://studentrobotics.org/docs"
 classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
- pyproject.toml `homepage` was missing the `/srobo`
- email address in .mailmap had a comma instead of a dot