### PR TITLE
Update marker size

### DIFF
--- a/sr/robot3/game.py
+++ b/sr/robot3/game.py
@@ -7,7 +7,7 @@ class UnusedMarkerException(Exception):
 
 
 MARKER_SIZES: Dict[Container[int], int] = {
-    range(28): 250,  # 0 - 27 for arena boundary
+    range(28): 200,  # 0 - 27 for arena boundary
 }
 
 


### PR DESCRIPTION
Markers are actually 200mm

> Each wall of the arena features seven 200mm AprilTag markers.

https://studentrobotics.org/docs/resources/2022/rulebook.html