### PR TITLE
Use calibration resolution for camera

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -100,25 +100,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coverage"
-version = "6.0.2"
+version = "6.3"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 tomli = {version = "*", optional = true, markers = "extra == \"toml\""}
 
 [package.extras]
 toml = ["tomli"]
-
-[[package]]
-name = "dataclasses"
-version = "0.8"
-description = "A backport of the dataclasses module for Python 3.6"
-category = "main"
-optional = false
-python-versions = ">=3.6, <3.7"
 
 [[package]]
 name = "dbus-next"
@@ -356,15 +348,15 @@ pyusb = ">=1.0,<2.0"
 
 [[package]]
 name = "j5-zoloto"
-version = "0.1.0"
+version = "0.2.0"
 description = "j5 integration for Zoloto computer vision"
 category = "main"
 optional = false
-python-versions = ">=3.6,<4.0"
+python-versions = ">=3.7,<4.0"
 
 [package.dependencies]
 j5 = ">=0.13.0,<0.14.0"
-zoloto = ">=0.7.0,<0.8.0"
+zoloto = ">=0.8.0,<0.9.0"
 
 [[package]]
 name = "jinja2"
@@ -491,9 +483,6 @@ description = "Data validation and settings management using python 3.6 type hin
 category = "main"
 optional = false
 python-versions = ">=3.6"
-
-[package.dependencies]
-dataclasses = {version = ">=0.6", markers = "python_version < \"3.7\""}
 
 [package.extras]
 dotenv = ["python-dotenv (>=0.10.4)"]
@@ -893,11 +882,11 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 
 [[package]]
 name = "zoloto"
-version = "0.7.0"
+version = "0.8.0"
 description = "A fiducial marker system powered by OpenCV - Supports ArUco and April"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 cached-property = ">=1.5"
@@ -905,13 +894,14 @@ numpy = "<1.21"
 pyquaternion = ">=0.9.2"
 
 [package.extras]
+cli = ["pillow", "tqdm"]
 opencv = ["opencv-contrib-python (>=4.0,<4.6)"]
 rpi = ["picamera[array] (>=1.13)"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.6"
-content-hash = "c6cf2fc1ef2e2ead6b1cf9a7d8a081f130fb766839793e877e72ff973949e450"
+python-versions = "^3.7"
+content-hash = "1fc17034d29de5463cb81ae8e24ff9736237382f13d3c46071b7b292667f64e7"
 
 [metadata.files]
 alabaster = [
@@ -955,43 +945,47 @@ colorama = [
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
-    {file = "coverage-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1549e1d08ce38259de2bc3e9a0d5f3642ff4a8f500ffc1b2df73fd621a6cdfc0"},
-    {file = "coverage-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcae10fccb27ca2a5f456bf64d84110a5a74144be3136a5e598f9d9fb48c0caa"},
-    {file = "coverage-6.0.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:53a294dc53cfb39c74758edaa6305193fb4258a30b1f6af24b360a6c8bd0ffa7"},
-    {file = "coverage-6.0.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8251b37be1f2cd9c0e5ccd9ae0380909c24d2a5ed2162a41fcdbafaf59a85ebd"},
-    {file = "coverage-6.0.2-cp310-cp310-win32.whl", hash = "sha256:db42baa892cba723326284490283a68d4de516bfb5aaba369b4e3b2787a778b7"},
-    {file = "coverage-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:bbffde2a68398682623d9dd8c0ca3f46fda074709b26fcf08ae7a4c431a6ab2d"},
-    {file = "coverage-6.0.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:60e51a3dd55540bec686d7fff61b05048ca31e804c1f32cbb44533e6372d9cc3"},
-    {file = "coverage-6.0.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6a6a9409223a27d5ef3cca57dd7cd4dfcb64aadf2fad5c3b787830ac9223e01a"},
-    {file = "coverage-6.0.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4b34ae4f51bbfa5f96b758b55a163d502be3dcb24f505d0227858c2b3f94f5b9"},
-    {file = "coverage-6.0.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3bbda1b550e70fa6ac40533d3f23acd4f4e9cb4e6e77251ce77fdf41b3309fb2"},
-    {file = "coverage-6.0.2-cp36-cp36m-win32.whl", hash = "sha256:4e28d2a195c533b58fc94a12826f4431726d8eb029ac21d874345f943530c122"},
-    {file = "coverage-6.0.2-cp36-cp36m-win_amd64.whl", hash = "sha256:a82d79586a0a4f5fd1cf153e647464ced402938fbccb3ffc358c7babd4da1dd9"},
-    {file = "coverage-6.0.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3be1206dc09fb6298de3fce70593e27436862331a85daee36270b6d0e1c251c4"},
-    {file = "coverage-6.0.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c9cd3828bbe1a40070c11fe16a51df733fd2f0cb0d745fb83b7b5c1f05967df7"},
-    {file = "coverage-6.0.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:d036dc1ed8e1388e995833c62325df3f996675779541f682677efc6af71e96cc"},
-    {file = "coverage-6.0.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:04560539c19ec26995ecfb3d9307ff154fbb9a172cb57e3b3cfc4ced673103d1"},
-    {file = "coverage-6.0.2-cp37-cp37m-win32.whl", hash = "sha256:e4fb7ced4d9dec77d6cf533acfbf8e1415fe799430366affb18d69ee8a3c6330"},
-    {file = "coverage-6.0.2-cp37-cp37m-win_amd64.whl", hash = "sha256:77b1da5767ed2f44611bc9bc019bc93c03fa495728ec389759b6e9e5039ac6b1"},
-    {file = "coverage-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:61b598cbdbaae22d9e34e3f675997194342f866bb1d781da5d0be54783dce1ff"},
-    {file = "coverage-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:36e9040a43d2017f2787b28d365a4bb33fcd792c7ff46a047a04094dc0e2a30d"},
-    {file = "coverage-6.0.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:9f1627e162e3864a596486774876415a7410021f4b67fd2d9efdf93ade681afc"},
-    {file = "coverage-6.0.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e7a0b42db2a47ecb488cde14e0f6c7679a2c5a9f44814393b162ff6397fcdfbb"},
-    {file = "coverage-6.0.2-cp38-cp38-win32.whl", hash = "sha256:a1b73c7c4d2a42b9d37dd43199c5711d91424ff3c6c22681bc132db4a4afec6f"},
-    {file = "coverage-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:1db67c497688fd4ba85b373b37cc52c50d437fd7267520ecd77bddbd89ea22c9"},
-    {file = "coverage-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f2f184bf38e74f152eed7f87e345b51f3ab0b703842f447c22efe35e59942c24"},
-    {file = "coverage-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cd1cf1deb3d5544bd942356364a2fdc8959bad2b6cf6eb17f47d301ea34ae822"},
-    {file = "coverage-6.0.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:ad9b8c1206ae41d46ec7380b78ba735ebb77758a650643e841dd3894966c31d0"},
-    {file = "coverage-6.0.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:381d773d896cc7f8ba4ff3b92dee4ed740fb88dfe33b6e42efc5e8ab6dfa1cfe"},
-    {file = "coverage-6.0.2-cp39-cp39-win32.whl", hash = "sha256:424c44f65e8be58b54e2b0bd1515e434b940679624b1b72726147cfc6a9fc7ce"},
-    {file = "coverage-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:abbff240f77347d17306d3201e14431519bf64495648ca5a49571f988f88dee9"},
-    {file = "coverage-6.0.2-pp36-none-any.whl", hash = "sha256:7092eab374346121805fb637572483270324407bf150c30a3b161fc0c4ca5164"},
-    {file = "coverage-6.0.2-pp37-none-any.whl", hash = "sha256:30922626ce6f7a5a30bdba984ad21021529d3d05a68b4f71ea3b16bda35b8895"},
-    {file = "coverage-6.0.2.tar.gz", hash = "sha256:6807947a09510dc31fa86f43595bf3a14017cd60bf633cc746d52141bfa6b149"},
-]
-dataclasses = [
-    {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
-    {file = "dataclasses-0.8.tar.gz", hash = "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"},
+    {file = "coverage-6.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e8071e7d9ba9f457fc674afc3de054450be2c9b195c470147fbbc082468d8ff7"},
+    {file = "coverage-6.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:86c91c511853dfda81c2cf2360502cb72783f4b7cebabef27869f00cbe1db07d"},
+    {file = "coverage-6.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c4ce3b647bd1792d4394f5690d9df6dc035b00bcdbc5595099c01282a59ae01"},
+    {file = "coverage-6.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2a491e159294d756e7fc8462f98175e2d2225e4dbe062cca7d3e0d5a75ba6260"},
+    {file = "coverage-6.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d008e0f67ac800b0ca04d7914b8501312c8c6c00ad8c7ba17754609fae1231a"},
+    {file = "coverage-6.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4578728c36de2801c1deb1c6b760d31883e62e33f33c7ba8f982e609dc95167d"},
+    {file = "coverage-6.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:7ee317486593193e066fc5e98ac0ce712178c21529a85c07b7cb978171f25d53"},
+    {file = "coverage-6.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2bc85664b06ba42d14bb74d6ddf19d8bfc520cb660561d2d9ce5786ae72f71b5"},
+    {file = "coverage-6.3-cp310-cp310-win32.whl", hash = "sha256:27a94db5dc098c25048b0aca155f5fac674f2cf1b1736c5272ba28ead2fc267e"},
+    {file = "coverage-6.3-cp310-cp310-win_amd64.whl", hash = "sha256:bde4aeabc0d1b2e52c4036c54440b1ad05beeca8113f47aceb4998bb7471e2c2"},
+    {file = "coverage-6.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7eed8459a2b81848cafb3280b39d7d49950d5f98e403677941c752e7e7ee47cb"},
+    {file = "coverage-6.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1b4285fde5286b946835a1a53bba3ad41ef74285ba9e8013e14b5ea93deaeafc"},
+    {file = "coverage-6.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a4748349734110fd32d46ff8897b561e6300d8989a494ad5a0a2e4f0ca974fc7"},
+    {file = "coverage-6.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:823f9325283dc9565ba0aa2d240471a93ca8999861779b2b6c7aded45b58ee0f"},
+    {file = "coverage-6.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:fff16a30fdf57b214778eff86391301c4509e327a65b877862f7c929f10a4253"},
+    {file = "coverage-6.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:da1a428bdbe71f9a8c270c7baab29e9552ac9d0e0cba5e7e9a4c9ee6465d258d"},
+    {file = "coverage-6.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:7d82c610a2e10372e128023c5baf9ce3d270f3029fe7274ff5bc2897c68f1318"},
+    {file = "coverage-6.3-cp37-cp37m-win32.whl", hash = "sha256:11e61c5548ecf74ea1f8b059730b049871f0e32b74f88bd0d670c20c819ad749"},
+    {file = "coverage-6.3-cp37-cp37m-win_amd64.whl", hash = "sha256:8e0c3525b1a182c8ffc9bca7e56b521e0c2b8b3e82f033c8e16d6d721f1b54d6"},
+    {file = "coverage-6.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a189036c50dcd56100746139a459f0d27540fef95b09aba03e786540b8feaa5f"},
+    {file = "coverage-6.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:32168001f33025fd756884d56d01adebb34e6c8c0b3395ca8584cdcee9c7c9d2"},
+    {file = "coverage-6.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5d79c9af3f410a2b5acad91258b4ae179ee9c83897eb9de69151b179b0227f5"},
+    {file = "coverage-6.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:85c5fc9029043cf8b07f73fbb0a7ab6d3b717510c3b5642b77058ea55d7cacde"},
+    {file = "coverage-6.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a7596aa2f2b8fa5604129cfc9a27ad9beec0a96f18078cb424d029fdd707468d"},
+    {file = "coverage-6.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:ce443a3e6df90d692c38762f108fc4c88314bf477689f04de76b3f252e7a351c"},
+    {file = "coverage-6.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:012157499ec4f135fc36cd2177e3d1a1840af9b236cbe80e9a5ccfc83d912a69"},
+    {file = "coverage-6.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:0a34d313105cdd0d3644c56df2d743fe467270d6ab93b5d4a347eb9fec8924d6"},
+    {file = "coverage-6.3-cp38-cp38-win32.whl", hash = "sha256:6e78b1e25e5c5695dea012be473e442f7094d066925604be20b30713dbd47f89"},
+    {file = "coverage-6.3-cp38-cp38-win_amd64.whl", hash = "sha256:433b99f7b0613bdcdc0b00cc3d39ed6d756797e3b078d2c43f8a38288520aec6"},
+    {file = "coverage-6.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9ed3244b415725f08ca3bdf02ed681089fd95e9465099a21c8e2d9c5d6ca2606"},
+    {file = "coverage-6.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ab4fc4b866b279740e0d917402f0e9a08683e002f43fa408e9655818ed392196"},
+    {file = "coverage-6.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c8582e9280f8d0f38114fe95a92ae8d0790b56b099d728cc4f8a2e14b1c4a18c"},
+    {file = "coverage-6.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c72bb4679283c6737f452eeb9b2a0e570acaef2197ad255fb20162adc80bea76"},
+    {file = "coverage-6.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca29c352389ea27a24c79acd117abdd8a865c6eb01576b6f0990cd9a4e9c9f48"},
+    {file = "coverage-6.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:152cc2624381df4e4e604e21bd8e95eb8059535f7b768c1fb8b8ae0b26f47ab0"},
+    {file = "coverage-6.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:51372e24b1f7143ee2df6b45cff6a721f3abe93b1e506196f3ffa4155c2497f7"},
+    {file = "coverage-6.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:72d9d186508325a456475dd05b1756f9a204c7086b07fffb227ef8cee03b1dc2"},
+    {file = "coverage-6.3-cp39-cp39-win32.whl", hash = "sha256:649df3641eb351cdfd0d5533c92fc9df507b6b2bf48a7ef8c71ab63cbc7b5c3c"},
+    {file = "coverage-6.3-cp39-cp39-win_amd64.whl", hash = "sha256:e67ccd53da5958ea1ec833a160b96357f90859c220a00150de011b787c27b98d"},
+    {file = "coverage-6.3-pp36.pp37.pp38-none-any.whl", hash = "sha256:27ac7cb84538e278e07569ceaaa6f807a029dc194b1c819a9820b9bb5dbf63ab"},
+    {file = "coverage-6.3.tar.gz", hash = "sha256:987a84ff98a309994ca77ed3cc4b92424f824278e48e4bf7d1bb79a63cfe2099"},
 ]
 dbus-next = [
     {file = "dbus_next-0.2.3-py3-none-any.whl", hash = "sha256:58948f9aff9db08316734c0be2a120f6dc502124d9642f55e90ac82ffb16a18b"},
@@ -1073,8 +1067,8 @@ j5 = [
     {file = "j5-0.13.0.tar.gz", hash = "sha256:069a98ad6f0dbf9f38bd3af7d0a114c9dca1427820c8978fe95012f97ea21a32"},
 ]
 j5-zoloto = [
-    {file = "j5_zoloto-0.1.0-py3-none-any.whl", hash = "sha256:cae0b60a3441ee4ef378aca7b87c65d018dd05d58dde2fd8c6bcf87894a0118e"},
-    {file = "j5_zoloto-0.1.0.tar.gz", hash = "sha256:5e1aa426f35fd5746655150e6f0f73c03edcbc27d4f7d872398d268d6f251b38"},
+    {file = "j5_zoloto-0.2.0-py3-none-any.whl", hash = "sha256:73f2e2a38ec64b81d94f320ce1fc204e3d827f02aae16e39cf2a11ab9e4178d7"},
+    {file = "j5_zoloto-0.2.0.tar.gz", hash = "sha256:e7040a14bb5b73b5c847de66e07037505c01810640ab7e7dc6e36e7adaf5e260"},
 ]
 jinja2 = [
     {file = "Jinja2-3.0.2-py3-none-any.whl", hash = "sha256:8569982d3f0889eed11dd620c706d39b60c36d6d25843961f33f77fb6bc6b20c"},
@@ -1445,6 +1439,6 @@ zipp = [
     {file = "zipp-3.6.0.tar.gz", hash = "sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832"},
 ]
 zoloto = [
-    {file = "zoloto-0.7.0-py3-none-any.whl", hash = "sha256:4719f7319caf3465da2b8380424b44f4a0be633030a60e2602741b92700dd70b"},
-    {file = "zoloto-0.7.0.tar.gz", hash = "sha256:d2f56ec10cc846c7431b54da067e389e457afc0f5ca17f1ebef127457ffd1037"},
+    {file = "zoloto-0.8.0-py3-none-any.whl", hash = "sha256:b74e2a4846f0f0b6e4daf0a21f4fcbc971a18497eabbb29078df80565472d27e"},
+    {file = "zoloto-0.8.0.tar.gz", hash = "sha256:885678a60cad8e8ed57d857a9c219b36f13f0e351124dcc6db3485050cc6f16f"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,9 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.7"
 j5 = "^0.13.0"
-j5-zoloto = "^0.1.0"
+j5-zoloto = "^0.2.0"
 pyserial = "^3.4"
 astoria = "^0.5.1"
 

--- a/sr/robot3/env.py
+++ b/sr/robot3/env.py
@@ -19,7 +19,7 @@ __all__ = [
     "CONSOLE_ENVIRONMENT",
 ]
 
-from sr.robot3.vision import SRZolotoSingleHardwareBackend
+from sr.robot3.vision import SRZolotoHardwareBackend
 
 HARDWARE_ENVIRONMENT = Environment("Hardware Environment")
 
@@ -27,7 +27,7 @@ HARDWARE_ENVIRONMENT.register_backend(SRV4PowerBoardHardwareBackend)
 HARDWARE_ENVIRONMENT.register_backend(SRV4ServoBoardHardwareBackend)
 HARDWARE_ENVIRONMENT.register_backend(SRV4MotorBoardHardwareBackend)
 HARDWARE_ENVIRONMENT.register_backend(SRV4RuggeduinoHardwareBackend)
-HARDWARE_ENVIRONMENT.register_backend(SRZolotoSingleHardwareBackend)
+HARDWARE_ENVIRONMENT.register_backend(SRZolotoHardwareBackend)
 
 CONSOLE_ENVIRONMENT = Environment("Console Environment")
 
@@ -42,4 +42,4 @@ CONSOLE_ENVIRONMENT_WITH_VISION.register_backend(SRV4PowerBoardConsoleBackend)
 CONSOLE_ENVIRONMENT_WITH_VISION.register_backend(SRV4ServoBoardConsoleBackend)
 CONSOLE_ENVIRONMENT_WITH_VISION.register_backend(SRV4MotorBoardConsoleBackend)
 CONSOLE_ENVIRONMENT_WITH_VISION.register_backend(SRV4RuggeduinoConsoleBackend)
-CONSOLE_ENVIRONMENT_WITH_VISION.register_backend(SRZolotoSingleHardwareBackend)
+CONSOLE_ENVIRONMENT_WITH_VISION.register_backend(SRZolotoHardwareBackend)

--- a/sr/robot3/robot.py
+++ b/sr/robot3/robot.py
@@ -95,15 +95,13 @@ class Robot(BaseRobot):
         """Initialise vision system for a single camera."""
         backend_class = self._environment.get_backend(ZolotoCameraBoard)
 
-        if backend_class is SRZolotoHardwareBackend:
-            backend = SRZolotoHardwareBackend(
-                0,
-                marker_offset=marker_offset,
-            )
-        else:
-            backend = backend_class(0)  # type: ignore
+        if backend_class is ZolotoHardwareBackend:
+            backend_class = SRZolotoHardwareBackend
 
-        self._camera = ZolotoCameraBoard("ZOLOTOCAM", backend)
+        self._cameras = BoardGroup.get_board_group(
+            ZolotoCameraBoard,
+            backend_class,
+        )
 
     def _init_power_board(self) -> None:
         """
@@ -167,7 +165,7 @@ class Robot(BaseRobot):
 
         :returns: a :class:`j5_zoloto.board.ZolotoCameraBoard`.
         """
-        return self._camera
+        return self._cameras.singular()
 
     @property
     def motor_boards(self) -> BoardGroup[MotorBoard, Backend]:

--- a/sr/robot3/robot.py
+++ b/sr/robot3/robot.py
@@ -101,9 +101,7 @@ class Robot(BaseRobot):
             backend_class = SRZolotoHardwareBackend
 
         class OffsetZolotoBackend(backend_class):  # type: ignore
-            """
-            A zoloto backend, with marker offsets added.
-            """
+            """A zoloto backend, with marker offsets added."""
 
             @classmethod
             def discover(cls) -> Set[Board]:

--- a/sr/robot3/robot.py
+++ b/sr/robot3/robot.py
@@ -20,7 +20,7 @@ from serial.tools.list_ports_common import ListPortInfo
 from .astoria import GetMetadataConsumer, WaitForStartButtonBroadcastConsumer
 from .env import HARDWARE_ENVIRONMENT
 from .timeout import kill_after_delay
-from .vision import SRZolotoSingleHardwareBackend
+from .vision import SRZolotoHardwareBackend
 
 __version__ = "2022.0.2"
 
@@ -95,8 +95,8 @@ class Robot(BaseRobot):
         """Initialise vision system for a single camera."""
         backend_class = self._environment.get_backend(ZolotoCameraBoard)
 
-        if backend_class is SRZolotoSingleHardwareBackend:
-            backend = SRZolotoSingleHardwareBackend(
+        if backend_class is SRZolotoHardwareBackend:
+            backend = SRZolotoHardwareBackend(
                 0,
                 marker_offset=marker_offset,
             )

--- a/sr/robot3/vision/__init__.py
+++ b/sr/robot3/vision/__init__.py
@@ -1,7 +1,7 @@
 """Vision API."""
 
-from .backend import SRZolotoSingleHardwareBackend
+from .backend import SRZolotoHardwareBackend
 
 __all__ = [
-    "SRZolotoSingleHardwareBackend",
+    "SRZolotoHardwareBackend",
 ]

--- a/sr/robot3/vision/backend.py
+++ b/sr/robot3/vision/backend.py
@@ -12,6 +12,7 @@ from typing import List, Optional, Tuple
 
 from j5_zoloto import ZolotoSingleHardwareBackend
 from numpy import ndarray  # type: ignore
+from zoloto.calibration import parse_calibration_file
 from zoloto.cameras import Camera
 from zoloto.marker_type import MarkerType
 
@@ -47,11 +48,17 @@ class SRZolotoCamera(Camera):
         calibration_file: Optional[Path] = None,
         marker_offset: int = 0,
     ) -> None:
+        if calibration_file is not None:
+            resolution = parse_calibration_file(calibration_file).resolution
+        else:
+            resolution = None
+
         super().__init__(
             camera_id,
             marker_size=marker_size,
             marker_type=marker_type,
             calibration_file=calibration_file,
+            resolution=resolution,
         )
         self._marker_offset = marker_offset
 

--- a/sr/robot3/vision/backend.py
+++ b/sr/robot3/vision/backend.py
@@ -10,7 +10,7 @@ import logging
 from pathlib import Path
 from typing import List, Optional, Tuple
 
-from j5_zoloto import ZolotoSingleHardwareBackend
+from j5_zoloto import ZolotoHardwareBackend
 from numpy import ndarray  # type: ignore
 from zoloto.calibration import parse_calibration_file
 from zoloto.cameras import Camera
@@ -89,7 +89,7 @@ class SRZolotoCamera(Camera):
         return get_marker_size(marker_id)
 
 
-class SRZolotoSingleHardwareBackend(ZolotoSingleHardwareBackend):
+class SRZolotoHardwareBackend(ZolotoHardwareBackend):
     """A camera backend which automatically finds camera calibration data."""
 
     camera_class = SRZolotoCamera

--- a/sr/robot3/vision/backend.py
+++ b/sr/robot3/vision/backend.py
@@ -48,10 +48,10 @@ class SRZolotoCamera(Camera):
         calibration_file: Optional[Path] = None,
         marker_offset: int = 0,
     ) -> None:
+        resolution: Optional[Tuple[int, int]] = None
+
         if calibration_file is not None:
             resolution = parse_calibration_file(calibration_file).resolution
-        else:
-            resolution = None
 
         super().__init__(
             camera_id,


### PR DESCRIPTION
Calibrations are resolution dependent, so these need to be the same. Rather than hardcode, we read the resolution from the calibration file.

Note: This depends on a [currently unreleased](https://github.com/RealOrangeOne/zoloto/pull/292/) feature of Zoloto, and so CI won't pass until that is released and updated. Just opening a draft with the required changes. This change is also currently untested.

Bigger note: The 2 cameras we ship have slightly different resolutions in their calibrations.