### PR TITLE
Supress OpenCV logs outside verbose

### DIFF
--- a/sr/robot3/robot.py
+++ b/sr/robot3/robot.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import os
 from datetime import timedelta
 from pathlib import Path
 from typing import Dict, List, Optional, Type
@@ -64,6 +65,9 @@ class Robot(BaseRobot):
 
         if verbose:
             LOGGER.setLevel(logging.DEBUG)
+            os.environ["OPENCV_LOG_LEVEL"] = "DEBUG"
+        else:
+            os.environ["OPENCV_LOG_LEVEL"] = "ERROR"
 
         if ignored_ruggeduinos is None:
             self._ignored_ruggeduino_serials = []


### PR DESCRIPTION
Competitors can see "warning" messages from OpenCV (used by `zoloto` for vision). This PR makes 2 changes:

- Changes the default logging level for OpenCV to error, so they only see messages which may actually affect them
- Allow `verbose` mode to also control OpenCV's log level, and set it to debug.

OpenCVs debug may be too noisy, but given the idea of it is to provide us with useful information, it's likely fine.