### PR TITLE
Use `OffsetZolotoBackend` correctly

### DIFF
--- a/sr/robot3/robot.py
+++ b/sr/robot3/robot.py
@@ -119,7 +119,7 @@ class Robot(BaseRobot):
 
         self._cameras = BoardGroup.get_board_group(
             ZolotoCameraBoard,
-            backend_class,
+            OffsetZolotoBackend,
         )
 
     def _init_power_board(self) -> None:


### PR DESCRIPTION
We were defining it, but never actually using it

This was introduced in https://github.com/srobo/sr-robot3/pull/45, where the class was originally defined.