### PR TITLE
Make the rest of the sub-100 markers be token sized

### DIFF
--- a/sr/robot3/game.py
+++ b/sr/robot3/game.py
@@ -8,6 +8,7 @@ class UnusedMarkerException(Exception):
 
 MARKER_SIZES: Dict[Container[int], int] = {
     range(28): 200,  # 0 - 27 for arena boundary
+    range(28, 100): 100,  # Everything else is a token
 }
 
 


### PR DESCRIPTION
This will work for this year and we may want to have some fixed sizes for the future (though we can do that when we get there).

See discussion at https://studentrobotics.slack.com/archives/CBP7UL6RG/p1663265916120709