### PR TITLE
Explicitly define `RPi.GPIO` as extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ pyserial = "^3.4"
 astoria = "^0.9.0"
 "RPi.GPIO" = {version = "^0.7.0", optional = true}
 
+[tool.poetry.extras]
+kch = ["RPi.GPIO"]
 
 [tool.poetry.dev-dependencies]
 flake8 = "*"


### PR DESCRIPTION
Optional dependencies aren't kept optional in wheels. See https://github.com/python-poetry/poetry/issues/2357

![image](https://user-images.githubusercontent.com/6527489/196500085-2127aa39-7a31-4eef-8dc0-0b5b832a2fe8.png)

Note: This will need modifying downstream to install `sr-robot3[kch]`. Excluding `kch` will just noop the kch functionality, which is ok for local environments.