### PR TITLE
Prevent border contour superseding the marker's edge and preventing detection

### DIFF
--- a/sr/robot3/vision/backend.py
+++ b/sr/robot3/vision/backend.py
@@ -10,6 +10,7 @@ import logging
 from pathlib import Path
 from typing import List, Optional, Tuple
 
+from cv2 import aruco_DetectorParameters
 from j5_zoloto import ZolotoHardwareBackend
 from numpy.typing import NDArray
 from zoloto.calibration import parse_calibration_file
@@ -89,6 +90,15 @@ class SRZolotoCamera(Camera):
         :returns: The size of the marker in millimetres.
         """
         return get_marker_size(marker_id)
+
+    def get_detector_params(self) -> aruco_DetectorParameters:
+        """Modify ArUco detector parameters to suit our needs."""
+        parameters = super().get_detector_params()
+
+        # Prevent border contour superseding the marker's edge and preventing detection
+        parameters.minMarkerDistanceRate = 0.035
+
+        return parameters
 
 
 class SRZolotoHardwareBackend(ZolotoHardwareBackend):

--- a/stubs/cv2/__init__.py
+++ b/stubs/cv2/__init__.py
@@ -1,0 +1,2 @@
+class aruco_DetectorParameters:
+    minMarkerDistanceRate: float


### PR DESCRIPTION
See https://github.com/RealOrangeOne/zoloto/pull/313 for more justification as to what this change does and why it's necessary.

I've tested this parameter change locally and I'm happy with it, however it probably wants additional testing before we consider shipping this.