### PR TITLE
Update MQTT

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -13,5 +13,7 @@ ignore =
     D107
     #Don't require imperative mood docstrings.
     D401
+    #Allow binary operators at the beginning of lines
+    W503
 
 max_line_length = 90

--- a/.flake8
+++ b/.flake8
@@ -13,7 +13,5 @@ ignore =
     D107
     #Don't require imperative mood docstrings.
     D401
-    #Allow binary operators at the beginning of lines
-    W503
 
 max_line_length = 90

--- a/poetry.lock
+++ b/poetry.lock
@@ -325,6 +325,17 @@ python-versions = ">=3.6"
 pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
+name = "paho-mqtt"
+version = "1.6.1"
+description = "MQTT version 5.0/3.1.1 client class"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+proxy = ["pysocks"]
+
+[[package]]
 name = "pluggy"
 version = "1.0.0"
 description = "plugin and hook calling mechanisms for python"
@@ -535,6 +546,14 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "types-paho-mqtt"
+version = "1.6.0.1"
+description = "Typing stubs for paho-mqtt"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "typing-extensions"
 version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -566,7 +585,7 @@ kch = ["RPi.GPIO"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "afcda1661eda0b63d4a3b5c084265934bbb37941a8339014a15982b9df6aeaaa"
+content-hash = "1edb93d38798a1aa900e4969a53b8b4978de97dc61e206c340be25e96955ac52"
 
 [metadata.files]
 astoria = [
@@ -776,6 +795,9 @@ packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
+paho-mqtt = [
+    {file = "paho-mqtt-1.6.1.tar.gz", hash = "sha256:2a8291c81623aec00372b5a85558a372c747cbca8e9934dfe218638b8eefc26f"},
+]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
@@ -888,6 +910,10 @@ tomli = [
 tomli-w = [
     {file = "tomli_w-1.0.0-py3-none-any.whl", hash = "sha256:9f2a07e8be30a0729e533ec968016807069991ae2fd921a78d42f429ae5f4463"},
     {file = "tomli_w-1.0.0.tar.gz", hash = "sha256:f463434305e0336248cac9c2dc8076b707d8a12d019dd349f5c1e382dd1ae1b9"},
+]
+types-paho-mqtt = [
+    {file = "types-paho-mqtt-1.6.0.1.tar.gz", hash = "sha256:55fedd890cf5a4cad4f968f6dde43a0fa886d8896a1936d3f14b6348655c20b5"},
+    {file = "types_paho_mqtt-1.6.0.1-py3-none-any.whl", hash = "sha256:6f6eace42fe2db311ee9a8a4ef5574a9c2f2fa95815d7acdce1574449b158af3"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ j5-zoloto = "^0.4.0"
 pyserial = "^3.4"
 astoria = "^0.9.0"
 "RPi.GPIO" = {version = "^0.7.0", optional = true}
+paho-mqtt = "^1.6.1"
 
 [tool.poetry.extras]
 kch = ["RPi.GPIO"]
@@ -45,6 +46,7 @@ pytest-cov = "*"
 rope = "*"
 isort = {version = "*",extras = ["pyproject"]}
 packaging = "*"
+types-paho-mqtt = "^1.6.0"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/sr/robot3/astoria.py
+++ b/sr/robot3/astoria.py
@@ -17,7 +17,7 @@ from astoria.common.ipc import (
 from astoria.common.metadata import Metadata
 from paho.mqtt.client import Client as MQTT
 from paho.mqtt.client import MQTTMessage
-from pydantic import parse_obj_as
+from pydantic import ValidationError, parse_obj_as
 
 from .mqtt import MQTTClient
 
@@ -80,9 +80,8 @@ class GetMetadataConsumer:
                 LOGGER.warn("Cannot get metadata, astmetad is not running")
         except JSONDecodeError:
             LOGGER.error("Could not decode JSON metadata.")
-        except pydantic.ValidationError as e:
+        except ValidationError as e:
             LOGGER.error(f"Unable to parse metadata message: {e}")
-            
 
     def _handle_astprocd_message(
         self,
@@ -101,9 +100,8 @@ class GetMetadataConsumer:
                 LOGGER.warn("Cannot get process info, astprocd is not running")
         except JSONDecodeError:
             LOGGER.error("Could not decode JSON metadata.")
-        except pydantic.ValidationError as e:
+        except ValidationError as e:
             LOGGER.error(f"Unable to parse process message: {e}")
-            
 
     @classmethod
     def get_metadata(cls, mqtt_client: MQTTClient) -> GetMetadataResult:

--- a/sr/robot3/astoria.py
+++ b/sr/robot3/astoria.py
@@ -1,24 +1,27 @@
 """Integration with Astoria."""
 
-import asyncio
 import logging
 from json import JSONDecodeError, loads
 from pathlib import Path
-from typing import Match, NamedTuple, Optional
+from queue import PriorityQueue
+from threading import Event
+from typing import Any, Generic, NamedTuple, Optional, Type, TypeVar
 
-from astoria.common.components import StateConsumer
+from astoria.common.config import AstoriaConfig
 from astoria.common.ipc import (
+    BroadcastEvent,
     MetadataManagerMessage,
     ProcessManagerMessage,
     StartButtonBroadcastEvent,
 )
 from astoria.common.metadata import Metadata
-from astoria.common.mqtt import BroadcastHelper
+from paho.mqtt.client import Client as MQTT
+from paho.mqtt.client import MQTTMessage
 from pydantic import parse_obj_as
 
-LOGGER = logging.getLogger(__name__)
+from .mqtt import MQTTClient
 
-loop = asyncio.get_event_loop()
+LOGGER = logging.getLogger(__name__)
 
 
 class GetMetadataResult(NamedTuple):
@@ -28,126 +31,199 @@ class GetMetadataResult(NamedTuple):
     usb_path: Path
 
 
-class GetMetadataConsumer(StateConsumer):
-    """Astoria consumer to fetch metadata."""
+class GetMetadataConsumer():
+    """MQTT consumer to fetch metadata."""
 
     name = "sr-robot3-metadata"
 
-    def _setup_logging(self, verbose: bool, *, welcome_message: bool = True) -> None:
-        """Use the logging from sr-robot3."""
-        # Suppress INFO messages from gmqtt
-        logging.getLogger("gmqtt").setLevel(logging.WARNING)
+    def __init__(self, mqtt_client: MQTTClient) -> None:
+        self._mqtt = mqtt_client
 
-    def _init(self) -> None:
-        """Initialise consumer."""
+        # Initialise consumer data structures.
         self._metadata_message: Optional[MetadataManagerMessage] = None
         self._proc_message: Optional[ProcessManagerMessage] = None
-        self._state_lock = asyncio.Lock()
-        self._mqtt.subscribe("astmetad", self._handle_astmetad_message)
-        self._mqtt.subscribe("astprocd", self._handle_astprocd_message)
+        self._astmetad_received = Event()
+        self._astprocd_received = Event()
 
-    async def _handle_astmetad_message(
+    def run(self, timeout: Optional[float] = None) -> bool:
+        """Entrypoint for the data component."""
+        self._mqtt.subscribe(
+            f"{self.name}/astmetad", self._handle_astmetad_message)
+        self._mqtt.subscribe(
+            f"{self.name}/astprocd", self._handle_astprocd_message)
+
+        timeout_step = (timeout / 2) if timeout is not None else None
+
+        # wait for both messages to be received with a timeout
+        # the division of time between each step is irrelevant,
+        # messages can arrive for either during the whole period
+        self._astmetad_received.wait(timeout=timeout_step)
+        timed_out = self._astprocd_received.wait(timeout=timeout_step)
+
+        self._mqtt.unsubscribe(f"{self.name}/astmetad")
+        self._mqtt.unsubscribe(f"{self.name}/astprocd")
+
+        return timed_out
+
+    def _handle_astmetad_message(
         self,
-        match: Match[str],
-        payload: str,
+        client: MQTT,
+        userdata: Any,
+        msg: MQTTMessage,
     ) -> None:
         """Handle astmetad status messages."""
-        async with self._state_lock:
-            try:
-                message = parse_obj_as(MetadataManagerMessage, loads(payload))
-                if message.status == MetadataManagerMessage.Status.RUNNING:
-                    LOGGER.debug("Received metadata")
-                    self._metadata_message = message
-                else:
-                    LOGGER.warn("Cannot get metadata, astmetad is not running")
-            except JSONDecodeError:
-                LOGGER.error("Could not decode JSON metadata.")
-            if self._metadata_message is not None and self._proc_message is not None:
-                self.halt(silent=True)
+        try:
+            message = parse_obj_as(MetadataManagerMessage, loads(msg.payload))
+            if message.status == MetadataManagerMessage.Status.RUNNING:
+                LOGGER.debug("Received metadata")
+                self._metadata_message = message
+            else:
+                LOGGER.warn("Cannot get metadata, astmetad is not running")
+        except JSONDecodeError:
+            LOGGER.error("Could not decode JSON metadata.")
+        if self._metadata_message is not None:
+            self._astmetad_received.set()
 
-    async def _handle_astprocd_message(
+    def _handle_astprocd_message(
         self,
-        match: Match[str],
-        payload: str,
+        client: MQTT,
+        userdata: Any,
+        msg: MQTTMessage,
     ) -> None:
         """Handle astprocd status messages."""
-        async with self._state_lock:
-            try:
-                message = parse_obj_as(ProcessManagerMessage, loads(payload))
-                if message.status == ProcessManagerMessage.Status.RUNNING:
-                    LOGGER.debug("Received process info")
-                    self._proc_message = message
-                else:
-                    LOGGER.warn("Cannot get process info, astprocd is not running")
-            except JSONDecodeError:
-                LOGGER.error("Could not decode JSON metadata.")
-            if self._metadata_message is not None and self._proc_message is not None:
-                self.halt(silent=True)
-
-    async def main(self) -> None:
-        """Main method of the command."""
-        await self.wait_loop()
+        try:
+            message = parse_obj_as(ProcessManagerMessage, loads(msg.payload))
+            if message.status == ProcessManagerMessage.Status.RUNNING:
+                LOGGER.debug("Received process info")
+                self._proc_message = message
+            else:
+                LOGGER.warn("Cannot get process info, astprocd is not running")
+        except JSONDecodeError:
+            LOGGER.error("Could not decode JSON metadata.")
+        if self._proc_message is not None:
+            self._astprocd_received.set()
 
     @classmethod
-    def get_metadata(cls) -> GetMetadataResult:
+    def get_metadata(cls, mqtt_client: MQTTClient) -> GetMetadataResult:
         """Get metadata."""
-        gmc = cls(False, None)
+        gmc = cls(mqtt_client)
+        config = AstoriaConfig.load()
 
-        metadata = Metadata.init(gmc.config)
+        metadata = Metadata.init(config)
         path = Path("/dev/null")
 
         try:
-            loop.run_until_complete(asyncio.wait_for(gmc.run(), timeout=0.1))
-            if gmc._metadata_message is not None:
-                metadata = gmc._metadata_message.metadata
+            timed_out = gmc.run(timeout=0.1)
+            if not timed_out:
+                if gmc._metadata_message is not None:
+                    metadata = gmc._metadata_message.metadata
 
-            if gmc._proc_message is not None and gmc._proc_message.disk_info is not None:
-                path = gmc._proc_message.disk_info.mount_path
+                if (
+                    gmc._proc_message is not None
+                    and gmc._proc_message.disk_info is not None
+                ):
+                    path = gmc._proc_message.disk_info.mount_path
+            else:
+                LOGGER.warning("Astoria took too long to respond, giving up.")
         except ConnectionRefusedError:
             LOGGER.warning("Unable to connect to MQTT broker")
-        except asyncio.TimeoutError:
-            LOGGER.warning("Astoria took too long to respond, giving up.")
 
         return GetMetadataResult(metadata, path)
 
 
-class WaitForStartButtonBroadcastConsumer(StateConsumer):
-    """Wait for a start button broadcast."""
+class WaitForStartButtonBroadcastConsumer:
+    """MQTT consumer to wait for a start button broadcast."""
 
-    name = "sr-robot3-wait-start"
+    def __init__(self, mqtt_client: MQTTClient, start_event: Event) -> None:
+        self._trigger_event = BroadcastHelper.get_helper(
+            mqtt_client,
+            StartButtonBroadcastEvent,
+            start_event,
+        )
+
+        self._start_event = start_event
+
+    def run(self) -> None:
+        """Entrypoint for the data component."""
+        self._start_event.wait()
+
+    def close(self) -> None:
+        """Tidy up BroadcastHelper subscriptions."""
+        # run BroadcastHelper __del__ routine to unsubscribe
+        del self._trigger_event
+
+
+T = TypeVar("T", bound=BroadcastEvent)
+
+
+class BroadcastHelper(Generic[T]):
+    """
+    Helper class to manage broadcast events.
+
+    Subscribes to broadcast/{name} topic, validates received messages
+    against the supplied schema and puts messages in a queue that can
+    be read by wait_broadcast.
+    """
 
     def __init__(
         self,
-        verbose: bool,
-        config_file: Optional[str],
-        start_event: asyncio.Event,
+        mqtt: 'MQTTClient',
+        name: str,
+        schema: Type[T],
+        message_event: Optional[Event] = None,
     ) -> None:
-        super().__init__(verbose, config_file)
-        self._start_event = start_event
+        self._mqtt = mqtt
+        self._name = name
+        self._schema = schema
 
-    def _setup_logging(self, verbose: bool, *, welcome_message: bool = True) -> None:
-        """Use the logging from sr-robot3."""
-        # Suppress INFO messages from gmqtt
-        logging.getLogger("gmqtt").setLevel(logging.WARNING)
+        self.message_received = message_event if message_event is not None else Event()
+        self._event_queue: PriorityQueue[T] = PriorityQueue()
+        self._mqtt.subscribe(f"broadcast/{name}", self._handle_broadcast)
 
-    def _init(self) -> None:
+    def __del__(self) -> None:
+        """Unsubscribe the broadcast topic on destruction."""
+        self._mqtt.unsubscribe(f"broadcast/{self._name}")
+
+    @classmethod
+    def get_helper(
+        cls, mqtt: 'MQTTClient', schema: Type[T], message_event: Optional[Event] = None,
+    ) -> 'BroadcastHelper[T]':
+        """Get the broadcast helper for a given event."""
+        return BroadcastHelper[T](mqtt, schema.name, schema)
+
+    def _handle_broadcast(
+        self,
+        client: MQTT,
+        userdata: Any,
+        msg: MQTTMessage,
+    ) -> None:
         """
-        Initialisation of the data component.
+        Handle a broadcast event message.
 
-        Called in the constructor of the parent class.
+        Inserts the event into the priority queue.
         """
-        self._trigger_event = BroadcastHelper.get_helper(
-            self._mqtt,
-            StartButtonBroadcastEvent,
+        try:
+            ev = parse_obj_as(self._schema, loads(msg.payload))
+            LOGGER.debug(
+                f"Received {ev.event_name} broadcast event from {ev.sender_name}",
+            )
+            self._event_queue.put(ev)
+            self.message_received.set()
+        except JSONDecodeError:
+            LOGGER.warning(f"Broadcast event {self._name} contained invalid JSON")
+
+    def send(self, **kwargs: Any) -> None:
+        """Send an event."""
+        data = self._schema(
+            event_name=self._schema.name,
+            sender_name=self._mqtt._client_name,
+            **kwargs,
+        )
+        self._mqtt.publish(
+            f"broadcast/{self._schema.name}",
+            data.json(),
         )
 
-    async def main(self) -> None:
-        """Wait for a trigger event."""
-        while not self._start_event.is_set():
-            # wait_broadcast waits forever until a broadcoast, so we will use a short
-            # timeout to ensure that the loop condition is checked.
-            try:
-                await asyncio.wait_for(self._trigger_event.wait_broadcast(), timeout=0.1)
-                self._start_event.set()
-            except asyncio.TimeoutError:
-                pass
+    def wait_broadcast(self, timeout: Optional[float] = None) -> T:
+        """Wait for an event on the given broadcast."""
+        return self._event_queue.get(timeout=timeout)

--- a/sr/robot3/mqtt.py
+++ b/sr/robot3/mqtt.py
@@ -46,7 +46,7 @@ class MQTTClient:
         self._client_name = client_name
 
         self._client = mqtt.Client(client_id=client_name, protocol=mqtt_version)
-        self._client.on_connect = self.__on_connect
+        self._client.on_connect = self._on_connect
 
     def connect(self, host: str, port: int) -> None:
         """
@@ -136,7 +136,7 @@ class MQTTClient:
         except ValueError:
             raise ValueError(f"Cannot publish to MQTT topic: {topic}")
 
-    def __on_connect(
+    def _on_connect(
         self, mqttc: mqtt.Client, obj: Any, flags: Dict[str, int], rc: int,
     ) -> None:
         """Callback run each time the client connects to the broker."""

--- a/sr/robot3/mqtt.py
+++ b/sr/robot3/mqtt.py
@@ -103,7 +103,7 @@ class MQTTClient:
     ) -> None:
         LOGGER.debug(f"Subscribing to {topic}")
         self._client.message_callback_add(topic, callback)
-        self._client.subscribe(topic, 1)
+        self._client.subscribe(topic, qos=1)
 
     def unsubscribe(self, topic: str) -> None:
         """Unsubscribe from a topic."""

--- a/sr/robot3/mqtt.py
+++ b/sr/robot3/mqtt.py
@@ -107,9 +107,16 @@ class MQTTClient:
         self._client.unsubscribe(topic)
 
     def publish(
-        self, topic: str, payload: Union[bytes, str], retain: bool = False,
+        self,
+        topic: str,
+        payload: Union[bytes, str],
+        retain: bool = False,
+        *,
+        auto_prefix_topic: bool = True,
     ) -> None:
         """Publish a message to the broker."""
+        if auto_prefix_topic and self.topic_prefix:
+            topic = f"{self.topic_prefix}/{topic}"
         self._client.publish(topic, payload=payload, retain=retain, qos=1)
 
     def __on_connect(

--- a/sr/robot3/mqtt.py
+++ b/sr/robot3/mqtt.py
@@ -60,7 +60,7 @@ class MQTTClient:
 
         try:
             self._client.connect(host, port, keepalive=60)
-        except (TimeoutError, ValueError):
+        except (TimeoutError, ValueError, ConnectionRefusedError):
             LOGGER.error(f"Failed to connect to MQTT broker at {host}:{port}")
             return
         self._client.loop_start()

--- a/sr/robot3/mqtt.py
+++ b/sr/robot3/mqtt.py
@@ -95,7 +95,7 @@ class MQTTClient:
     ) -> None:
         LOGGER.debug(f"Subscribing to {topic}")
         self._client.message_callback_add(topic, callback)
-        self._client.subscribe(topic)
+        self._client.subscribe(topic, 1)
 
     def unsubscribe(self, topic: str) -> None:
         """Unsubscribe from a topic."""
@@ -110,7 +110,7 @@ class MQTTClient:
         self, topic: str, payload: Union[bytes, str], retain: bool = False,
     ) -> None:
         """Publish a message to the broker."""
-        self._client.publish(topic, payload=payload, retain=retain)
+        self._client.publish(topic, payload=payload, retain=retain, qos=1)
 
     def __on_connect(
         self, mqttc: mqtt.Client, obj: Any, flags: Dict[str, int], rc: int,

--- a/sr/robot3/mqtt.py
+++ b/sr/robot3/mqtt.py
@@ -1,0 +1,120 @@
+"""Wrapper around paho-mqtt."""
+
+import atexit
+import logging
+from typing import Any, Callable, Dict, Optional, Union
+
+import paho.mqtt.client as mqtt
+from astoria.common.config import AstoriaConfig
+
+LOGGER = logging.getLogger(__name__)
+
+
+def init_mqtt(client_name: str = 'sr-robot3') -> 'MQTTClient':
+    """
+    Helper method to create an MQTT client and connect.
+
+    Uses values from astoria's config.
+    """
+    config = AstoriaConfig.load()
+    client = MQTTClient.establish(
+        host=config.mqtt.host,
+        port=config.mqtt.port,
+        client_name=client_name,
+        mqtt_version=(
+            mqtt.MQTTv311
+            if config.mqtt.force_protocol_version_3_1
+            else mqtt.MQTTv5),
+        topic_prefix=config.mqtt.topic_prefix,
+    )
+    return client
+
+
+class MQTTClient:
+    """Class to handle MQTT subscriptions and callbacks."""
+
+    def __init__(
+        self,
+        client_name: Optional[str] = None,
+        mqtt_version: int = mqtt.MQTTv5,
+        topic_prefix: Optional[str] = None,
+    ) -> None:
+        self.subscriptions: Dict[
+            str, Callable[[mqtt.Client, Any, mqtt.MQTTMessage], None],
+        ] = {}
+        self.topic_prefix = topic_prefix
+        self._client_name = client_name
+
+        self._client = mqtt.Client(client_id=client_name, protocol=mqtt_version)
+        self._client.on_connect = self.__on_connect
+
+    def connect(self, host: str, port: int) -> None:
+        """
+        Connect to the MQTT broker and start event loop in background thread.
+
+        Registers an atexit routine that tears down the client.
+        """
+        self._client.connect(host, port, keepalive=60)
+        self._client.loop_start()
+        atexit.register(self.disconnect)
+
+    @classmethod
+    def establish(
+        cls, host: str, port: int, **kwargs: Any,
+    ) -> 'MQTTClient':
+        """Create client and connect."""
+        client = cls(**kwargs)
+        client.connect(host, port)
+        return client
+
+    def disconnect(self) -> None:
+        """Disconnect from the broker and close background event loop."""
+        self._client.disconnect()
+        self._client.loop_stop()
+        atexit.unregister(self.disconnect)
+
+    def subscribe(
+        self,
+        topic: str,
+        callback: Callable[[mqtt.Client, Any, mqtt.MQTTMessage], None],
+        override_prefix: bool = False,
+    ) -> None:
+        """Subscribe to a topic and assign a callback for messages."""
+        if not override_prefix and self.topic_prefix is not None:
+            full_topic = f"{self.topic_prefix}/{topic}"
+        else:
+            full_topic = topic
+
+        self.subscriptions[full_topic] = callback
+        self._subscribe(full_topic, callback)
+
+    def _subscribe(
+        self,
+        topic: str,
+        callback: Callable[[mqtt.Client, Any, mqtt.MQTTMessage], None],
+    ) -> None:
+        LOGGER.debug(f"Subscribing to {topic}")
+        self._client.message_callback_add(topic, callback)
+        self._client.subscribe(topic)
+
+    def unsubscribe(self, topic: str) -> None:
+        """Unsubscribe from a topic."""
+        try:
+            del self.subscriptions[topic]
+        except KeyError:
+            pass
+        self._client.message_callback_remove(topic)
+        self._client.unsubscribe(topic)
+
+    def publish(
+        self, topic: str, payload: Union[bytes, str], retain: bool = False,
+    ) -> None:
+        """Publish a message to the broker."""
+        self._client.publish(topic, payload=payload, retain=retain)
+
+    def __on_connect(
+        self, mqttc: mqtt.Client, obj: Any, flags: Dict[str, int], rc: int,
+    ) -> None:
+        """Callback run each time the client connects to the broker."""
+        for topic, callback in self.subscriptions.items():
+            self._subscribe(topic, callback)

--- a/sr/robot3/robot.py
+++ b/sr/robot3/robot.py
@@ -170,9 +170,9 @@ class Robot(BaseRobot):
 
     def _init_metadata(self) -> None:
         """Fetch metadata from Astoria."""
-        (
-            self._metadata, self._code_path,
-        ) = GetMetadataConsumer.get_metadata(self._mqtt)
+        self._metadata, self._code_path = GetMetadataConsumer.get_metadata(
+            self._mqtt,
+        )
         offset = self._metadata.marker_offset
         if hasattr(self, '_cameras'):
             for camera in self._cameras:
@@ -384,10 +384,8 @@ class Robot(BaseRobot):
         counter = 0
         led_state = False
         _ = self.power_board.start_button.is_pressed
-        while (
-            not self.power_board.start_button.is_pressed
-            and not start_event.is_set()
-        ):
+        while not self.power_board.start_button.is_pressed and \
+            not start_event.is_set():
             if counter % 6 == 0:
                 led_state = not led_state
                 self.power_board._run_led.state = led_state

--- a/sr/robot3/robot.py
+++ b/sr/robot3/robot.py
@@ -385,7 +385,7 @@ class Robot(BaseRobot):
         led_state = False
         _ = self.power_board.start_button.is_pressed
         while not self.power_board.start_button.is_pressed and \
-            not start_event.is_set():
+                not start_event.is_set():
             if counter % 6 == 0:
                 led_state = not led_state
                 self.power_board._run_led.state = led_state


### PR DESCRIPTION
Fixes the issue with make_safe not running when killed from the webUI when used with https://github.com/srobo/astoria/pull/180.

Decouples the MQTT section of Astoria from sr-robot3, the message structures are still imported from Astoria.
To avoid the issues surrounding appropriate methods to do async event loop clean up in a largely synchronous codebase, this moves to using the paho-mqtt library which uses a background thread to handle the network loop. Cleanup is then handled by an atexit handler to disconnect and close the network loop thread.

To keep it simple there is a single long running client that is created within the robot's init routine and metadata and wait_start are done by temporarily subscribing to the relevant topics. Timeouts are used on the threading Events to prevent indefinite blocking.