### PR TITLE
Improve marker detection in difficult lighting

### DIFF
--- a/sr/robot3/vision/backend.py
+++ b/sr/robot3/vision/backend.py
@@ -10,6 +10,7 @@ import logging
 from pathlib import Path
 from typing import List, Optional, Tuple
 
+from cv2 import aruco_DetectorParameters
 from j5_zoloto import ZolotoHardwareBackend
 from numpy.typing import NDArray
 from zoloto.calibration import parse_calibration_file
@@ -89,6 +90,15 @@ class SRZolotoCamera(Camera):
         :returns: The size of the marker in millimetres.
         """
         return get_marker_size(marker_id)
+
+    def get_detector_params(self) -> aruco_DetectorParameters:
+        """Modify ArUco detector parameters to suit our needs."""
+        parameters = super().get_detector_params()
+
+        # Prevent border contour superseding the marker's edge and preventing detection
+        parameters.minMarkerDistanceRate = 0.035
+
+        return parameters
 
 
 class SRZolotoHardwareBackend(ZolotoHardwareBackend):

--- a/sr/robot3/vision/backend.py
+++ b/sr/robot3/vision/backend.py
@@ -98,6 +98,9 @@ class SRZolotoCamera(Camera):
         # Prevent border contour superseding the marker's edge and preventing detection
         parameters.minMarkerDistanceRate = 0.035
 
+        # Increase adaptive threshold window to improve detection in low light
+        parameters.adaptiveThreshWinSizeMax = 53
+
         return parameters
 
 

--- a/stubs/cv2/__init__.py
+++ b/stubs/cv2/__init__.py
@@ -1,2 +1,3 @@
 class aruco_DetectorParameters:
     minMarkerDistanceRate: float
+    adaptiveThreshWinSizeMax: int

--- a/stubs/cv2/__init__.py
+++ b/stubs/cv2/__init__.py
@@ -1,0 +1,2 @@
+class aruco_DetectorParameters:
+    minMarkerDistanceRate: float


### PR DESCRIPTION
Built on #74

This increases the number of adaptive thresholding steps which are performed when detecting marker contours. This will help improve marker detection in more difficult lighting conditions.

`53` results in twice the number of steps being performed (23 being the default max value, with the window starting at 3 and increasing by 10 each time).

This patch has been tested in similar ways to #74. It's worth noting that whilst these thesholds are performed in parallel, this patch **will slow down marker detection**. By exactly how much isn't clear, but locally it was around 20%.