### PR TITLE
Update B500 and C270 calibrations

### DIFF
--- a/sr/robot3/vision/calibrations/Logitech B500.xml
+++ b/sr/robot3/vision/calibrations/Logitech B500.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <opencv_storage>
-<calibrationDate>"Thu 11 Nov 2021 17:34:35 GMT"</calibrationDate>
-<framesCount>29</framesCount>
+<calibrationDate>"Wed 23 Nov 2022 21:23:00 GMT"</calibrationDate>
+<framesCount>15</framesCount>
 <cameraResolution>
   1280 1024</cameraResolution>
 <cameraMatrix type_id="opencv-matrix">
@@ -9,8 +9,9 @@
   <cols>3</cols>
   <dt>d</dt>
   <data>
-    9.3012007264063072e+02 0. 7.0226810811512655e+02 0.
-    9.3012007264063072e+02 4.7705847029705535e+02 0. 0. 1.</data></cameraMatrix>
+    1.05711133e+03 0. 6.02433099e+02
+    0. 1.06661029e+03 4.51876692e+02
+    0. 0. 1.</data></cameraMatrix>
 <cameraMatrix_std_dev type_id="opencv-matrix">
   <rows>4</rows>
   <cols>1</cols>
@@ -23,8 +24,7 @@
   <cols>5</cols>
   <dt>d</dt>
   <data>
-    -9.2701468925095482e-02 2.9255285923072902e-02
-    -7.9310903187861364e-03 1.1943725785898814e-02 0.</data></dist_coeffs>
+    -0.0930654 0.30046762 -0.00657921 -0.00055965 -0.48481949</data></dist_coeffs>
 <dist_coeffs_std_dev type_id="opencv-matrix">
   <rows>5</rows>
   <cols>1</cols>

--- a/sr/robot3/vision/calibrations/Logitech C270.xml
+++ b/sr/robot3/vision/calibrations/Logitech C270.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <opencv_storage>
-<calibrationDate>"Sun 10 Oct 2021 18:13:27 BST"</calibrationDate>
+<calibrationDate>"Tue 22 Nov 2022 18:45:00 GMT"</calibrationDate>
 <framesCount>29</framesCount>
 <cameraResolution>
   1280 960</cameraResolution>
@@ -9,8 +9,9 @@
   <cols>3</cols>
   <dt>d</dt>
   <data>
-    1.5125977852617134e+03 0. 5.8171757235186294e+02 0.
-    1.5125977852617134e+03 4.3694004497775438e+02 0. 0. 1.</data></cameraMatrix>
+    1.38752826e+03 0. 6.81279056e+02
+    0. 1.38764512e+03 5.32635142e+02
+    0. 0. 1.</data></cameraMatrix>
 <cameraMatrix_std_dev type_id="opencv-matrix">
   <rows>4</rows>
   <cols>1</cols>
@@ -23,9 +24,8 @@
   <cols>5</cols>
   <dt>d</dt>
   <data>
-    7.2702844094386473e-02 -1.0598889277707855e-02
-    -1.1532488282097528e-02 -1.7548754719661115e-02
-    -8.6188802908401987e-02</data></dist_coeffs>
+    0.01737599  0.36629486 -0.00773113  0.00315102 -1.34355748
+  </data></dist_coeffs>
 <dist_coeffs_std_dev type_id="opencv-matrix">
   <rows>5</rows>
   <cols>1</cols>


### PR DESCRIPTION
B500 distance error reduced from 20.588% to 2.487% 
C270 distance error reduced from 14.742% to 0.972%

Generated with a modified version of: https://gist.github.com/naoki-mizuno/d25cbc3c59228291cabe50529d70894c