### PR TITLE
Set debug level on all loggers in verbose

### DIFF
--- a/sr/robot3/robot.py
+++ b/sr/robot3/robot.py
@@ -68,7 +68,8 @@ class Robot(BaseRobot):
         self._environment = env
 
         if verbose:
-            LOGGER.setLevel(logging.DEBUG)
+            # Set root logger to DEBUG level
+            logging.getLogger().setLevel(logging.DEBUG)
             os.environ["OPENCV_LOG_LEVEL"] = "DEBUG"
         else:
             os.environ["OPENCV_LOG_LEVEL"] = "ERROR"


### PR DESCRIPTION
Currrently we only set DEBUG on sr.robot3.robot logger.