### PR TITLE
Bump GitHub Actions Checkout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-latest]
         python: [3.8, 3.9, "3.10", "3.11"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v1
         with:


### PR DESCRIPTION
This avoids deprecation of Node 12 (which Actions warn about already) and Note 16 which is likely to come soon given that it is now also beyond end of life.