### PR TITLE
Bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,16 +14,16 @@ jobs:
         os: [ubuntu-latest]
         python: [3.8, 3.9, "3.10", "3.11"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Install Poetry
         run: pip install poetry
       - name: Use in-project virtualenv
         run: poetry config virtualenvs.in-project true
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: .venv/
           key: ${{ runner.os }}-${{ matrix.python }}-pip-${{ hashFiles('poetry.lock') }}-${{ hashFiles('pyproject.toml') }}


### PR DESCRIPTION
This avoids deprecation of Node 12 (which Actions warn about already) and Note 16 which is likely to come soon given that it is now also beyond end of life.